### PR TITLE
fix: have a queue for each active soundboard overlay connection instead of having just one global queue

### DIFF
--- a/src/chatbot2k/app_state.py
+++ b/src/chatbot2k/app_state.py
@@ -2,6 +2,7 @@ import asyncio
 from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from chatbot2k.broadcasters.broadcaster import Broadcaster
 from chatbot2k.config import Config
@@ -46,7 +47,7 @@ class AppState(ABC):
 
     @property
     @abstractmethod
-    def soundboard_clips_url_queue(self) -> asyncio.Queue:
+    def soundboard_clips_url_queues(self) -> dict[UUID, asyncio.Queue[str]]:
         pass
 
     @property

--- a/src/chatbot2k/command_handlers/clip_handler.py
+++ b/src/chatbot2k/command_handlers/clip_handler.py
@@ -22,7 +22,8 @@ class ClipHandler(CommandHandler):
     @override
     async def handle_command(self, chat_command: ChatCommand) -> Optional[list[ChatResponse]]:
         if self._app_state.is_soundboard_enabled and chat_command.source_chat.feature_flags.can_trigger_soundboard:
-            await self._app_state.soundboard_clips_url_queue.put(self._clip_url)
+            for queue in self._app_state.soundboard_clips_url_queues.values():
+                await queue.put(self._clip_url)
         return []
 
     @override

--- a/src/chatbot2k/globals.py
+++ b/src/chatbot2k/globals.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Final
 from typing import final
 from typing import override
+from uuid import UUID
 
 from chatbot2k.app_state import AppState
 from chatbot2k.broadcasters.broadcaster import Broadcaster
@@ -28,7 +29,7 @@ class Globals(AppState):
     def __init__(self) -> None:
         self._is_soundboard_enabled = True
         self._config: Final = Config()
-        self._soundboard_clips_url_queue: Final[asyncio.Queue[str]] = asyncio.Queue()
+        self._soundboard_clips_url_queues: Final[dict[UUID, asyncio.Queue[str]]] = {}
         self._constants: Final = load_constants(
             constants_file=self.config.constants_file,
             create_if_missing=True,
@@ -80,8 +81,8 @@ class Globals(AppState):
 
     @override
     @property
-    def soundboard_clips_url_queue(self) -> asyncio.Queue[str]:
-        return self._soundboard_clips_url_queue
+    def soundboard_clips_url_queues(self) -> dict[UUID, asyncio.Queue[str]]:
+        return self._soundboard_clips_url_queues
 
     @override
     @property


### PR DESCRIPTION
This seems to also solve the other bug, so this fixes #5 and fixes #6.